### PR TITLE
Close parenthesis properly

### DIFF
--- a/pcoin.cpp
+++ b/pcoin.cpp
@@ -358,7 +358,7 @@ int add_file_value(const char* file_name, const long long int &value_to_add, con
 
   if(!file2) //error
   {
-    std::cerr << "Fatal error " << ERR_ADD_FILE_VALUE_FATAL << ": the file \"" << file_name << "\" was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide to report this error (because it requires manual recovery).";
+    std::cerr << "Fatal error " << ERR_ADD_FILE_VALUE_FATAL << ": the file \"" << file_name << "\" was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide) to report this error (because it requires manual recovery).";
     exit_program(ERR_ADD_FILE_VALUE_FATAL);
   }
   else
@@ -892,7 +892,7 @@ int send_message(const char* sender_username, const char* receiver_username, con
 
       if(!fout) //error
       {
-        std::cerr << "Fatal error " << ERR_SEND_MESSAGE_RECEIVER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the receiver message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide to report this error (because it requires manual recovery).";
+        std::cerr << "Fatal error " << ERR_SEND_MESSAGE_RECEIVER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the receiver message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide) to report this error (because it requires manual recovery).";
         exit_program(ERR_SEND_MESSAGE_RECEIVER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL);
       }
       else
@@ -983,7 +983,7 @@ int send_message(const char* sender_username, const char* receiver_username, con
 
             if(!fout) //error
             {
-              std::cerr << "Fatal error " << ERR_SEND_MESSAGE_PROGRAM_RECEIVER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the receiver program_message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide to report this error (because it requires manual recovery).";
+              std::cerr << "Fatal error " << ERR_SEND_MESSAGE_PROGRAM_RECEIVER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the receiver program_message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide) to report this error (because it requires manual recovery).";
               exit_program(ERR_SEND_MESSAGE_PROGRAM_RECEIVER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL);
             }
             else
@@ -1084,7 +1084,7 @@ int send_message(const char* sender_username, const char* receiver_username, con
 
           if(!fout) //error
           {
-            std::cerr << "Fatal error " << ERR_SEND_MESSAGE_SENDER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the sender message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide to report this error (because it requires manual recovery).";
+            std::cerr << "Fatal error " << ERR_SEND_MESSAGE_SENDER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the sender message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide) to report this error (because it requires manual recovery).";
             exit_program(ERR_SEND_MESSAGE_SENDER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL);
           }
           else
@@ -1172,7 +1172,7 @@ int send_message(const char* sender_username, const char* receiver_username, con
 
                 if(!fout) //error
                 {
-                  std::cerr << "Fatal error " << ERR_SEND_MESSAGE_SENDER_PROGRAM_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the sender program message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide to report this error (because it requires manual recovery).";
+                  std::cerr << "Fatal error " << ERR_SEND_MESSAGE_SENDER_PROGRAM_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the sender program message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide) to report this error (because it requires manual recovery).";
                   exit_program(ERR_SEND_MESSAGE_SENDER_PROGRAM_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL);
                 }
                 else

--- a/tcoin.cpp
+++ b/tcoin.cpp
@@ -345,7 +345,7 @@ int add_file_value(const char* file_name, const long long int &value_to_add, con
 
   if(!file2) //error
   {
-    std::cerr << "Fatal error " << ERR_ADD_FILE_VALUE_FATAL << ": the file \"" << file_name << "\" was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide to report this error (because it requires manual recovery).";
+    std::cerr << "Fatal error " << ERR_ADD_FILE_VALUE_FATAL << ": the file \"" << file_name << "\" was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide) to report this error (because it requires manual recovery).";
     exit_program(ERR_ADD_FILE_VALUE_FATAL);
   }
   else
@@ -1083,7 +1083,7 @@ int send_message(const char* sender_username, const char* receiver_username, con
 
       if(!fout) //error
       {
-        std::cerr << "Fatal error" << ERR_SEND_MESSAGE_RECEIVER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the receiver message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide to report this error (because it requires manual recovery).";
+        std::cerr << "Fatal error" << ERR_SEND_MESSAGE_RECEIVER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the receiver message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide) to report this error (because it requires manual recovery).";
         exit_program(ERR_SEND_MESSAGE_RECEIVER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL);
       }
       else
@@ -1174,7 +1174,7 @@ int send_message(const char* sender_username, const char* receiver_username, con
 
             if(!fout) //error
             {
-              std::cerr << "Fatal error " << ERR_SEND_MESSAGE_PROGRAM_RECEIVER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the receiver program_message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide to report this error (because it requires manual recovery).";
+              std::cerr << "Fatal error " << ERR_SEND_MESSAGE_PROGRAM_RECEIVER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the receiver program_message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide) to report this error (because it requires manual recovery).";
               exit_program(ERR_SEND_MESSAGE_PROGRAM_RECEIVER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL);
             }
             else
@@ -1274,7 +1274,7 @@ int send_message(const char* sender_username, const char* receiver_username, con
 
           if(!fout) //error
           {
-            std::cerr << "Fatal error " << ERR_SEND_MESSAGE_SENDER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the sender message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide to report this error (because it requires manual recovery).";
+            std::cerr << "Fatal error " << ERR_SEND_MESSAGE_SENDER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL << ": the sender message file was unable to be updated. Please contact login@tilde.town (town-only) or login@tilde.team (internet-wide) to report this error (because it requires manual recovery).";
             exit_program(ERR_SEND_MESSAGE_SENDER_MSG_FILE_UNABLE_TO_BE_UPDATED_FATAL);
           }
           else


### PR DESCRIPTION
As seems login forgot to close a parenthesis in the manual recovery
messages, and also appears like I am hunting for errors in tcoin :)
I have just changed the instances of the manual recovery messages from
"login@tilde.town (town-only) or login@tilde.team (internet wide [...]"
to:
"login@tilde.town (town-only) or login@tilde.team (internet wide) [...]"